### PR TITLE
Fix issue with error when the context object is not set

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,15 @@ exports.register = function (plugin, options, next) {
 
         // Check to see if the response is a view
         if (response.variety === 'view') {
-                if(_.isEmpty(response.source.context.assets)){
-                    response.source.context.assets = {};
-                }
-                response.source.context.assets = options[environment];
+
+            if(_.isEmpty(response.source.context)){
+                response.source.context = {};
+            }
+
+            if(_.isEmpty(response.source.context.assets)){
+                response.source.context.assets = {};
+            }
+            response.source.context.assets = options[environment];
         }
         return next();
     });


### PR DESCRIPTION
I noticed that the hapi-assets plugin fails when the context is not already set in the `reply.view()` call. For example, if you were to do something like:

``` js
handler: function(request, reply){
          // Render the view (response.source.context will not be set)
            reply.view('index');
        },
...
handler: function(request, reply){
          // Render the view (response.source.context will be set as we are passing in an object)
            reply.view('index', { title: 'hi!'');
        },
```

This PR addresses that issue.
